### PR TITLE
fix: only change active text editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,16 +103,9 @@ function setStatus(enabled: boolean) {
   if (enabled) {
     statusBarItem.text = "$(check) Auto Scroll";
     goToLastLine(vscode.window.activeTextEditor);
-
-    vscode.window.visibleTextEditors.forEach((editor) =>
-      activeEditors.set(editor.document.uri.toString(), editor)
-    );
+    activeEditors.set(vscode.window.activeTextEditor.document.uri.toString(), vscode.window.activeTextEditor);
   } else {
     statusBarItem.text = "$(x) Auto Scroll";
-
-    vscode.window.visibleTextEditors.forEach((editor) =>
-      activeEditors.delete(editor.document.uri.toString())
-    );
   }
 
   isEnable = enabled;


### PR DESCRIPTION
when opening multiple panels at the same time, it is not rational to change the auto scroll status of them all